### PR TITLE
Minetest 5.1.0 compatibility

### DIFF
--- a/bonemeal.lua
+++ b/bonemeal.lua
@@ -1,5 +1,8 @@
 
 
 bonemeal:add_sapling({
-	{"redwood:redwood_sapling", redwood.grow_sapling, "default:dirt_with_dry_grass"}
+	{"redwood:redwood_sapling", redwood.grow_sapling, "default:dirt_with_dry_grass"},
+	{"redwood:redwood_sapling", redwood.grow_sapling, "default:dirt"},
+	{"redwood:redwood_sapling", redwood.grow_sapling, "default:dry_dirt"},
+	{"redwood:redwood_sapling", redwood.grow_sapling, "default:dry_dirt_with_dry_grass"}
 })

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -2,7 +2,7 @@
 
 minetest.register_decoration({
 	deco_type = "simple",
-	place_on = {"default:dirt_with_dry_grass"},
+	place_on = {"default:dirt_with_dry_grass", "default:dry_dirt_with_dry_grass"},
 	sidelen = 32,
 	noise_params = {
 		offset = 0,

--- a/sapling.lua
+++ b/sapling.lua
@@ -103,7 +103,10 @@ redwood.grow_sapling = function(pos)
 		return
 	end
 
-	if under == "default:dirt_with_dry_grass" then
+	if under == "default:dirt_with_dry_grass"
+		or under == "default:dirt"
+		or under == "default:dry_dirt_with_dry_grass"
+		or under == "default:dry_dirt" then
 		redwood.grow_redwood_tree(pos)
 	end
 


### PR DESCRIPTION
Redwood can now generate naturally on `default:dry_dirt_with_dry_grass`, and can also be grown from a sapling on `default:dirt` and `default:dry_dirt`.