### PR TITLE
Is ground content

### DIFF
--- a/leaves.lua
+++ b/leaves.lua
@@ -12,6 +12,7 @@ minetest.register_node("redwood:redwood_leaves", {
 	paramtype = "light",
 	walkable = false,
 	waving = 1,
+	is_ground_content = false,
 	groups = {snappy = 3, leafdecay = 3, leaves = 1, flammable = 2},
 	drop = {
 		max_items = 1,

--- a/wood.lua
+++ b/wood.lua
@@ -7,6 +7,7 @@ minetest.register_node("redwood:redwood_trunk", {
 		"redwood_trunk_top.png",
 		"redwood_trunk.png"
 	},
+	is_ground_content = false,
 	groups = {tree = 1, choppy = 2, oddly_breakable_by_hand = 1, flammable = 2},
 	sounds = default.node_sound_wood_defaults(),
 	paramtype2 = "facedir",


### PR DESCRIPTION
see https://github.com/pandorabox-io/pandorabox.io/issues/836

note: MTG declares trunk, wood and leaves as non ground content but saplings as ground content.
I'm OK with having saplings be non ground content too so I didn't change that in this commit.